### PR TITLE
Fixed small typo in parsoid article URL construction

### DIFF
--- a/mwoffliner.js
+++ b/mwoffliner.js
@@ -1450,7 +1450,7 @@ function saveArticles( finished ) {
     }
 
     function saveArticle( articleId, finished ) {
-	var articleUrl = parsoidUrl + encodeURIComponent( articleId ) + ( parsoidUrl.indexOf( '/rest' ) < 0 ? '&oldid=' : '/' ) + articleIds[ articleId ];
+	var articleUrl = parsoidUrl + encodeURIComponent( articleId ) + ( parsoidUrl.indexOf( '/rest' ) < 0 ? '?oldid=' : '/' ) + articleIds[ articleId ];
 	printLog( 'Getting article from ' + articleUrl );
 	setTimeout( skipHtmlCache ? downloadContent : downloadContentAndCache, downloadFileQueue.length() + optimizationQueue.length(), articleUrl, function( content, responseHeaders, articleId ) {
 	    var html = '';

--- a/mwoffliner.js
+++ b/mwoffliner.js
@@ -1450,7 +1450,7 @@ function saveArticles( finished ) {
     }
 
     function saveArticle( articleId, finished ) {
-	var articleUrl = parsoidUrl + encodeURIComponent( articleId ) + ( parsoidUrl.indexOf( '/rest' ) < 0 ? '?oldid=' : '/' ) + articleIds[ articleId ];
+	var articleUrl = parsoidUrl + encodeURIComponent( articleId ) + ( parsoidUrl.indexOf( '/rest' ) < 0 ? (parsoidUrl.indexOf( '?' ) < 0 ? '?' : '&' ) + 'oldid=' : '/' ) + articleIds[ articleId ];
 	printLog( 'Getting article from ' + articleUrl );
 	setTimeout( skipHtmlCache ? downloadContent : downloadContentAndCache, downloadFileQueue.length() + optimizationQueue.length(), articleUrl, function( content, responseHeaders, articleId ) {
 	    var html = '';


### PR DESCRIPTION
Result URL was in incorrect format:
example before: http://parsoid.url/.../articleName&oldid=1234  (missing ? delimeter for queryset arguments)
example after: http://parsoid.url/.../articleName?oldid=1234 (queryset is now ok)